### PR TITLE
Makes ResourceAuthorization Async

### DIFF
--- a/source/Owin.ResourceAuthorization.Mvc/HttpContextExtensions.cs
+++ b/source/Owin.ResourceAuthorization.Mvc/HttpContextExtensions.cs
@@ -20,10 +20,10 @@ namespace System.Web
         {
             var cp = httpContext.User as ClaimsPrincipal;
             var authorizationContext = new ResourceAuthorizationContext(
+                httpContext.Response.ClientDisconnectedToken,
                 cp ?? Principal.Anonymous,
                 action,
                 resources);
-
             return httpContext.CheckAccessAsync(authorizationContext);
         }
 

--- a/source/Owin.ResourceAuthorization/ResourceAuthorizationContext.cs
+++ b/source/Owin.ResourceAuthorization/ResourceAuthorizationContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
 
 namespace Thinktecture.IdentityModel.Owin.ResourceAuthorization
 {
@@ -10,8 +11,9 @@ namespace Thinktecture.IdentityModel.Owin.ResourceAuthorization
         public IEnumerable<Claim> Action { get; set; }
         public IEnumerable<Claim> Resource { get; set; }
         public ClaimsPrincipal Principal { get; set; }
+        public CancellationToken CancellationToken { get; set; }
 
-        public ResourceAuthorizationContext(ClaimsPrincipal principal, IEnumerable<Claim> action, IEnumerable<Claim> resource)
+        public ResourceAuthorizationContext(ClaimsPrincipal principal, IEnumerable<Claim> action, IEnumerable<Claim> resource, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (action == null)
             {
@@ -31,9 +33,10 @@ namespace Thinktecture.IdentityModel.Owin.ResourceAuthorization
             Action = action;
             Resource = resource;
             Principal = principal;
+            CancellationToken = cancellationToken;
         }
 
-        public ResourceAuthorizationContext(ClaimsPrincipal principal, string action, params string[] resource)
+        public ResourceAuthorizationContext(CancellationToken cancellationToken, ClaimsPrincipal principal, string action, params string[] resource)
         {
             if (string.IsNullOrWhiteSpace(action))
             {
@@ -53,6 +56,7 @@ namespace Thinktecture.IdentityModel.Owin.ResourceAuthorization
             Action = new List<Claim> { new Claim("name", action) };
             Resource = new List<Claim>(from r in resource select new Claim("name", r));
             Principal = principal;
+            CancellationToken = cancellationToken;
         }
     }
 }


### PR DESCRIPTION
Changes the ResourceAuthorizeAttribute to not inherit from
Authorize filter, instead it implements IAuthorizationFilter
which allows a full async pipeline with cancellation support.

There are some breaking changes in the public API to get
the CancellationToken support, its an ugly API since it takes
"params" in several spots so adding a simple overload at the
end for a CancellationToken doesn't work well.

Should fix issues from #112
