### PR TITLE
Added Federation metadata endpoint

### DIFF
--- a/samples/EmbeddedSts/EmbeddedStsSample.sln
+++ b/samples/EmbeddedSts/EmbeddedStsSample.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmbeddedStsSample", "EmbeddedStsSample\EmbeddedStsSample.csproj", "{6CB43772-C1BF-4215-B3F6-CE77B717360F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thinktecture.IdentityModel.EmbeddedSts", "..\..\source\Thinktecture.IdentityModel.EmbeddedSts\Thinktecture.IdentityModel.EmbeddedSts.csproj", "{408440E6-E84F-4ECD-AEBA-F3D963EAC166}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thinktecture.IdentityModel.EmbeddedSts", "..\..\source\EmbeddedSts\EmbeddedSts.csproj", "{408440E6-E84F-4ECD-AEBA-F3D963EAC166}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/samples/EmbeddedSts/EmbeddedStsSample/Web.config
+++ b/samples/EmbeddedSts/EmbeddedStsSample/Web.config
@@ -82,6 +82,7 @@
                     issuer="http://EmbeddedSts"
                     realm="https://localhost/EmbeddedStsSample/"
                     requireHttps="false"
+                    reply="http://localhost:29702/"
       />
     </federationConfiguration>
   </system.identityModel.services>

--- a/source/EmbeddedSts/EmbeddedSts.csproj
+++ b/source/EmbeddedSts/EmbeddedSts.csproj
@@ -41,30 +41,7 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.WebPages.3.0.0\lib\net45\System.Web.Helpers.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.Mvc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.Mvc.5.0.0\lib\net45\System.Web.Mvc.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.Razor.3.0.0\lib\net45\System.Web.Razor.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.WebPages.3.0.0\lib\net45\System.Web.WebPages.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.WebPages.3.0.0\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.WebPages.3.0.0\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.Web.Mvc" />    
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />

--- a/source/EmbeddedSts/EmbeddedSts.csproj
+++ b/source/EmbeddedSts/EmbeddedSts.csproj
@@ -30,14 +30,41 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.identitymodel.services" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Mvc" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.WebPages.3.0.0\lib\net45\System.Web.Helpers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.Mvc.5.0.0\lib\net45\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.Razor.3.0.0\lib\net45\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.WebPages.3.0.0\lib\net45\System.Web.WebPages.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.WebPages.3.0.0\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\samples\EmbeddedSts\packages\Microsoft.AspNet.WebPages.3.0.0\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />
@@ -59,6 +86,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Assets\SignIn.html" />
     <EmbeddedResource Include="Assets\SignOut.html" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/source/EmbeddedSts/EmbeddedSts.csproj
+++ b/source/EmbeddedSts/EmbeddedSts.csproj
@@ -37,7 +37,7 @@
     <Reference Include="System.identitymodel.services" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Mvc" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />

--- a/source/EmbeddedSts/EmbeddedStsConfiguration.cs
+++ b/source/EmbeddedSts/EmbeddedStsConfiguration.cs
@@ -88,11 +88,19 @@ namespace Thinktecture.IdentityModel.EmbeddedSts
             var routes = RouteTable.Routes;
 
             routes.MapRoute(
+                "EmbeddedSts-WSFederationMetadata",
+                "FederationMetadata",
+                new { controller = "EmbeddedSts", action = "WsFederationMetadata" },
+                null,
+                new string[] { "Thinktecture.IdentityModel.EmbeddedSts" }
+                );
+
+            routes.MapRoute(
                 "EmbeddedSts-WsFed",
                 EmbeddedStsConstants.WsFedPath,
                 new { controller = "EmbeddedSts", action = "Index" },
                 null,
-                new string[] { "Thinktecture.IdentityModel.EmbeddedSts" });
+                new string[] { "Thinktecture.IdentityModel.EmbeddedSts" });            
         }
     }
 }

--- a/source/EmbeddedSts/EmbeddedStsConfiguration.cs
+++ b/source/EmbeddedSts/EmbeddedStsConfiguration.cs
@@ -100,7 +100,7 @@ namespace Thinktecture.IdentityModel.EmbeddedSts
                 EmbeddedStsConstants.WsFedPath,
                 new { controller = "EmbeddedSts", action = "Index" },
                 null,
-                new string[] { "Thinktecture.IdentityModel.EmbeddedSts" });            
+                new string[] { "Thinktecture.IdentityModel.EmbeddedSts" });
         }
     }
 }

--- a/source/EmbeddedSts/EmbeddedStsConstants.cs
+++ b/source/EmbeddedSts/EmbeddedStsConstants.cs
@@ -10,14 +10,15 @@ namespace Thinktecture.IdentityModel.EmbeddedSts
 {
     public class EmbeddedStsConstants
     {
+        public static string WsFederationMetadata = "/FederationMetadata/2007-06/FederationMetadata.xml";
         public const string EmbeddedStsIssuerHost = "EmbeddedSts";
-        public const string TokenIssuerName = "urn:Thinktecture:EmbeddedSTS";
+        public const string TokenIssuerName = "urn:Thinktecture:EmbeddedSTS";                
 
         internal const int SamlTokenLifetime = 60 * 10;
 
         internal const string SigningCertificateFile = "EmbeddedSigningCert.pfx";
         internal const string SigningCertificatePassword = "password";
-
+        
         internal const string SignInFile = "SignIn.html";
         internal const string SignOutFile = "SignOut.html";
 

--- a/source/EmbeddedSts/EmbeddedStsConstants.cs
+++ b/source/EmbeddedSts/EmbeddedStsConstants.cs
@@ -9,8 +9,7 @@ using Thinktecture.IdentityModel.EmbeddedSts.Assets;
 namespace Thinktecture.IdentityModel.EmbeddedSts
 {
     public class EmbeddedStsConstants
-    {
-        public static string WsFederationMetadata = "/FederationMetadata/2007-06/FederationMetadata.xml";
+    {        
         public const string EmbeddedStsIssuerHost = "EmbeddedSts";
         public const string TokenIssuerName = "urn:Thinktecture:EmbeddedSTS";
 

--- a/source/EmbeddedSts/EmbeddedStsConstants.cs
+++ b/source/EmbeddedSts/EmbeddedStsConstants.cs
@@ -12,13 +12,13 @@ namespace Thinktecture.IdentityModel.EmbeddedSts
     {
         public static string WsFederationMetadata = "/FederationMetadata/2007-06/FederationMetadata.xml";
         public const string EmbeddedStsIssuerHost = "EmbeddedSts";
-        public const string TokenIssuerName = "urn:Thinktecture:EmbeddedSTS";                
+        public const string TokenIssuerName = "urn:Thinktecture:EmbeddedSTS";
 
         internal const int SamlTokenLifetime = 60 * 10;
 
         internal const string SigningCertificateFile = "EmbeddedSigningCert.pfx";
         internal const string SigningCertificatePassword = "password";
-        
+
         internal const string SignInFile = "SignIn.html";
         internal const string SignOutFile = "SignOut.html";
 

--- a/source/EmbeddedSts/UserManager.cs
+++ b/source/EmbeddedSts/UserManager.cs
@@ -44,9 +44,9 @@ namespace Thinktecture.IdentityModel.EmbeddedSts
         public static IList<string> GetAllUniqueClaimTypes()
         {
             var users = GetAllUsers();            
-            var b = users.SelectMany(c => c.Claims).Select(o => o.Type).Distinct().ToList();
+            var claims = users.SelectMany(c => c.Claims).Select(o => o.Type).Distinct().ToList();
 
-            return b;
+            return claims;
         } 
 
         static IEnumerable<User> GetAllUsers()

--- a/source/EmbeddedSts/UserManager.cs
+++ b/source/EmbeddedSts/UserManager.cs
@@ -41,6 +41,14 @@ namespace Thinktecture.IdentityModel.EmbeddedSts
             return claims;
         }
 
+        public static IList<string> GetAllUniqueClaimTypes()
+        {
+            var users = GetAllUsers();            
+            var b = users.SelectMany(c => c.Claims).Select(o => o.Type).Distinct().ToList();
+
+            return b;
+        } 
+
         static IEnumerable<User> GetAllUsers()
         {
             var ser = new JavaScriptSerializer();

--- a/source/EmbeddedSts/WsFed/EmbeddedStsController.cs
+++ b/source/EmbeddedSts/WsFed/EmbeddedStsController.cs
@@ -20,7 +20,7 @@ namespace Thinktecture.IdentityModel.EmbeddedSts.WsFed
         private ContentResult Html(string html)
         {
             return Content(html, "text/html");
-        }       
+        }
 
         public ActionResult Index()
         {
@@ -59,10 +59,10 @@ namespace Thinktecture.IdentityModel.EmbeddedSts.WsFed
                 options += String.Format("<option value='{0}'>{0}</option>", user);
             }
             html = html.Replace("{options}", options);
-
+            
             var url = Request.Url.PathAndQuery;
             html = html.Replace("{signInUrl}", url);
-
+            
             return Html(html);
         }
 
@@ -73,7 +73,7 @@ namespace Thinktecture.IdentityModel.EmbeddedSts.WsFed
 
             var claims = UserManager.GetClaimsForUser(username);
             if (claims == null || !claims.Any()) return null;
-
+            
             var id = new ClaimsIdentity(claims);
             return new ClaimsPrincipal(id);
         }

--- a/source/EmbeddedSts/WsFed/EmbeddedStsController.cs
+++ b/source/EmbeddedSts/WsFed/EmbeddedStsController.cs
@@ -84,7 +84,9 @@ namespace Thinktecture.IdentityModel.EmbeddedSts.WsFed
             var appPath = Request.ApplicationPath;
             if (!appPath.EndsWith("/")) appPath += "/";
 
-            signInMsg.Reply = new Uri(Request.Url, appPath).AbsoluteUri;
+            // when the reply querystringparameter has been specified, don't overrule it. 
+            if(String.IsNullOrEmpty(signInMsg.Reply))
+                signInMsg.Reply = new Uri(Request.Url, appPath).AbsoluteUri;
             var response = FederatedPassiveSecurityTokenServiceOperations.ProcessSignInRequest(signInMsg, user, sts);
 
             var body = response.WriteFormPost();

--- a/source/EmbeddedSts/WsFed/EmbeddedStsController.cs
+++ b/source/EmbeddedSts/WsFed/EmbeddedStsController.cs
@@ -20,12 +20,7 @@ namespace Thinktecture.IdentityModel.EmbeddedSts.WsFed
         private ContentResult Html(string html)
         {
             return Content(html, "text/html");
-        }
-
-        private ContentResult Xml(string xml)
-        {
-            return Content(xml, "application/xml");
-        }
+        }       
 
         public ActionResult Index()
         {

--- a/source/EmbeddedSts/WsFed/EmbeddedTokenServiceConfiguration.cs
+++ b/source/EmbeddedSts/WsFed/EmbeddedTokenServiceConfiguration.cs
@@ -4,13 +4,20 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Security.Claims;
 using System.IdentityModel.Configuration;
+using System.IdentityModel.Metadata;
+using System.IdentityModel.Protocols.WSTrust;
 using System.IdentityModel.Tokens;
+using System.Xml;
+using System.Xml.Linq;
 
 namespace Thinktecture.IdentityModel.EmbeddedSts.WsFed
 {
     class EmbeddedTokenServiceConfiguration : SecurityTokenServiceConfiguration
     {
+
         public EmbeddedTokenServiceConfiguration()
             : base(false)
         {
@@ -19,5 +26,43 @@ namespace Thinktecture.IdentityModel.EmbeddedSts.WsFed
             this.SigningCredentials = new X509SigningCredentials(EmbeddedStsConstants.SigningCertificate);
             this.DefaultTokenLifetime = TimeSpan.FromMinutes(EmbeddedStsConstants.SamlTokenLifetime);
         }
+
+        public XElement GetFederationMetadata(string endPoint, IList<string> claims)
+        {                        
+            System.ServiceModel.EndpointAddress item = new System.ServiceModel.EndpointAddress(endPoint + "/_sts/");
+            EntityDescriptor entityDescriptor = new EntityDescriptor(new EntityId(this.TokenIssuerName));
+            SecurityTokenServiceDescriptor securityTokenServiceDescriptor = new SecurityTokenServiceDescriptor();
+            entityDescriptor.RoleDescriptors.Add(securityTokenServiceDescriptor);            
+            KeyDescriptor keyDescriptor = new KeyDescriptor(this.SigningCredentials.SigningKeyIdentifier);
+            keyDescriptor.Use = KeyType.Signing;
+            securityTokenServiceDescriptor.Keys.Add(keyDescriptor);
+            for (int i = 0; i < claims.Count; i++)
+            {
+                securityTokenServiceDescriptor.ClaimTypesOffered.Add(new DisplayClaim(claims[i], claims[i], string.Empty));
+            }
+
+            var endPointReference = new EndpointReference(item.Uri.ToString());
+            securityTokenServiceDescriptor.PassiveRequestorEndpoints.Add(endPointReference);
+            securityTokenServiceDescriptor.ProtocolsSupported.Add(new System.Uri("http://docs.oasis-open.org/wsfed/federation/200706"));
+            securityTokenServiceDescriptor.SecurityTokenServiceEndpoints.Add(endPointReference);
+            entityDescriptor.SigningCredentials = base.SigningCredentials;
+            MetadataSerializer metadataSerializer = new MetadataSerializer();
+            XElement result = null;
+            using (System.IO.MemoryStream memoryStream = new System.IO.MemoryStream())
+            {
+                metadataSerializer.WriteMetadata(memoryStream, entityDescriptor);
+                memoryStream.Flush();
+                memoryStream.Seek(0L, System.IO.SeekOrigin.Begin);
+                XmlReaderSettings settings = new XmlReaderSettings();
+                settings.IgnoreComments = true;
+                settings.IgnoreWhitespace = true;                
+                XmlReader reader = XmlReader.Create(memoryStream);
+                result = XElement.Load(reader);
+            }
+            
+
+            return result;
+        }
+       
     }
 }

--- a/source/EmbeddedSts/packages.config
+++ b/source/EmbeddedSts/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.Mvc" version="5.0.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
After making this STS suitable to run as a very simple STS that can be consumed by various applications, I added a WSFederationMetadata endpoint: OWIN can be used to consume that endpoint, which makes it much more convenient to setup a Claims based application. 

This STS can be used now on development enviroments for consumption by for example SharePoint, in combination with the (complex) Claims Based High trust provider hosted web applications. This approach easens up that kind of development
