### PR TITLE
fixing potential async deadlock.

### DIFF
--- a/source/Owin.ResourceAuthorization.WebApi/ResourceAuthorizeAttribute.cs
+++ b/source/Owin.ResourceAuthorization.WebApi/ResourceAuthorizeAttribute.cs
@@ -51,7 +51,7 @@ namespace Thinktecture.IdentityModel.WebApi
 
         protected virtual bool CheckAccess(HttpRequestMessage request, Claim[] actions, params Claim[] resources)
         {
-            var task = request.CheckAccessAsync(actions, resources);
+            var task = Task.Run(() => request.CheckAccessAsync(actions, resources));
 
             if (task.Wait(5000))
             {


### PR DESCRIPTION
Just been fighting an rather annoying async deadlock issue.

Information on the async deadlock from a similar issue i had before that let me find the solution rather quickly.
http://stackoverflow.com/questions/30841406/how-to-avoid-async-await-deadlock-when-blocking-is-required
http://blog.stephencleary.com/2012/07/dont-block-on-async-code.html 

anyway, to ensure that nothing goes into a deadlock the PR provides a simple fix that will save others the headache of putting the Task.Run into their application code.
