### PR TITLE
Correct Typo in HmacSigningCredentials Exception

### DIFF
--- a/source/Core/Tokens/HmacSigningCredentials.cs
+++ b/source/Core/Tokens/HmacSigningCredentials.cs
@@ -32,7 +32,7 @@ namespace Thinktecture.IdentityModel.Tokens
                 case 64:
                     return Algorithms.HmacSha512Signature;
                 default:
-                    throw new InvalidOperationException("Unsupported key lenght");
+                    throw new InvalidOperationException("Unsupported key length");
             }
         }
 


### PR DESCRIPTION
Fixes a typo in the HmacSigningCredentials: `lenght` -> `length`