### PR TITLE
Null check in ScopeAuthorizeAttribute

### DIFF
--- a/source/WebApi.ScopeAuthorization/ScopeAuthorizeAttribute.cs
+++ b/source/WebApi.ScopeAuthorization/ScopeAuthorizeAttribute.cs
@@ -59,8 +59,7 @@ namespace Thinktecture.IdentityModel.WebApi
         protected override void HandleUnauthorizedRequest(HttpActionContext actionContext)
         {
             HttpResponseMessage response;
-
-            if (actionContext.RequestContext.Principal.Identity.IsAuthenticated)
+            if (actionContext.RequestContext.Principal != null && actionContext.RequestContext.Principal.Identity.IsAuthenticated)
             {
                 response = actionContext.Request.CreateErrorResponse(HttpStatusCode.Forbidden, "insufficient_scope");
                 response.Headers.Add("WWW-Authenticate", "Bearer error=\"insufficient_scope\"");


### PR DESCRIPTION
RequestContext.Principal can be null which causes Internal Server error.