### PR TITLE
Expose scopes

### DIFF
--- a/source/WebApi/ScopeAuthorizeAttribute.cs
+++ b/source/WebApi/ScopeAuthorizeAttribute.cs
@@ -19,6 +19,11 @@ namespace Thinktecture.IdentityModel.WebApi
         string[] _scopes;
         static string _scopeClaimType = "scope";
 
+        public string[] Scopes
+        {
+            get { return _scopes;}
+        }
+
         public static string ScopeClaimType 
         {
             get { return _scopeClaimType; }


### PR DESCRIPTION
We're programmatically generating docs for our REST API and would like to iterate the scopes during runtime.