### PR TITLE
Make Authentication headers case insensitive

### DIFF
--- a/source/WebApi.AuthNHandler/AuthenticationConfiguration.cs
+++ b/source/WebApi.AuthNHandler/AuthenticationConfiguration.cs
@@ -120,7 +120,7 @@ namespace Thinktecture.IdentityModel.WebApi.Authentication.Handler
         {
             handler = (from m in Mappings
                        where m.Options.RequestType == HttpRequestType.Header &&
-                             m.Options.Name == headerName
+                             m.Options.Name.ToLowerInvariant() == headerName.ToLowerInvariant()
                        select m.TokenHandler).SingleOrDefault();
 
             return (handler != null);


### PR DESCRIPTION
According to [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2) HTTP headers names are case-insensitive.