### PR TITLE
Prevent null reference exception when RouteData.Value is null

### DIFF
--- a/source/Owin.ResourceAuthorization.WebApi/HttpActionContextExtensions.cs
+++ b/source/Owin.ResourceAuthorization.WebApi/HttpActionContextExtensions.cs
@@ -9,7 +9,7 @@ namespace Thinktecture.IdentityModel.WebApi
     {
         public static IEnumerable<Claim> ResourcesFromRouteParameters(this HttpActionContext actionContext)
         {
-            return actionContext.ControllerContext.RouteData.Values.Select(arg => new Claim(arg.Key, arg.Value.ToString()));
+            return actionContext.ControllerContext.RouteData.Values.Select(arg => new Claim(arg.Key, (arg.Value ?? "").ToString()));
         }
 
         public static List<Claim> ResourceFromController(this HttpActionContext actionContext)


### PR DESCRIPTION
In our project, for some reason. the odataPath RouteData value is null, which blows this up.